### PR TITLE
Fix: Declares Class Properties

### DIFF
--- a/public/classes/CommandLine.php
+++ b/public/classes/CommandLine.php
@@ -8,6 +8,8 @@ namespace Palasthotel\WordPress\MigrateToGutenberg;
  * @property Plugin plugin
  */
 class CommandLine {
+	public $plugin;
+
 	public function __construct( Plugin $plugin ) {
 		$this->plugin = $plugin;
 	}

--- a/public/classes/Components/Component.php
+++ b/public/classes/Components/Component.php
@@ -12,6 +12,7 @@ namespace Palasthotel\WordPress\MigrateToGutenberg\Components;
  * @version 0.1.2
  */
 abstract class Component {
+	public $plugin;
 	/**
 	 * _Component constructor.
 	 *

--- a/public/classes/Components/Database.php
+++ b/public/classes/Components/Database.php
@@ -10,6 +10,7 @@ use wpdb;
  * @version 0.1.1
  */
 abstract class Database {
+	public $wpdb;
 
 	public function __construct() {
 		global $wpdb;

--- a/public/classes/Components/Plugin.php
+++ b/public/classes/Components/Plugin.php
@@ -17,7 +17,9 @@ abstract class Plugin {
 	 * @var ReflectionClass
 	 */
 	private $ref;
-
+	private $path;
+	private $url;
+	private $basename;
 	private $tooLateForTextdomain;
 
 	/**

--- a/public/classes/Menu.php
+++ b/public/classes/Menu.php
@@ -14,6 +14,8 @@ use Palasthotel\WordPress\MigrateToGutenberg\Views\PostMigrationsTable;
  * @property PostMigrationPreview preview
  */
 class Menu extends Component {
+	private $diff;
+	private $preview;
 
 	const SLUG = "m2g";
 
@@ -100,7 +102,7 @@ class Menu extends Component {
         $table      = new PostMigrationsTable( $migrations );
         $table->prepare_items();
         $table->views();
-		//$table->search_box("Search", "search");
+		// $table->search_box("Search", "search");
         $table->display();
 
         ?>

--- a/public/classes/Store/MigrationsDatabase.php
+++ b/public/classes/Store/MigrationsDatabase.php
@@ -9,6 +9,7 @@ use Palasthotel\WordPress\MigrateToGutenberg\Components\Database;
  * @property string table
  */
 class MigrationsDatabase extends Database {
+	public $table;
 
 	function init() {
 		$this->table = $this->wpdb->prefix."m2g_migrations";

--- a/public/m2g.php
+++ b/public/m2g.php
@@ -30,6 +30,11 @@ require_once dirname( __FILE__ ) . "/vendor/autoload.php";
  * @property Actions actions
  */
 class Plugin extends Components\Plugin {
+	public $menu;
+	public $ajax;
+	public $actions;
+	public $dbMigrations;
+	public $migrationController;
 
 	const DOMAIN = "m2g";
 


### PR DESCRIPTION
PHP 8.2: Dynamic Properties are deprecated, so the properties should be declared.

Fixes #6 
